### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_sign_publish.yml
+++ b/.github/workflows/build_sign_publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   build-sign-publish:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ZjzMisaka/PowerThreadPool/security/code-scanning/2](https://github.com/ZjzMisaka/PowerThreadPool/security/code-scanning/2)

To fix this issue, add the `permissions` key at the root level of the workflow (to apply to all jobs unless overridden) or within the specific job (`build-sign-publish`) to limit the permissions of the `GITHUB_TOKEN`. Based on the operations performed in the workflow, the permissions can be set as follows:
- `contents: read` to allow the workflow to read repository contents.
- Additional permissions are not required for this workflow since it uses secrets to perform sensitive operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
