### PR TITLE
[*] use e.ID in TestDependentsSucceeded because first work may done and call WorkEnded before QueueWorkItem returns its ID

### DIFF
--- a/UnitTest/PowerPoolTest.cs
+++ b/UnitTest/PowerPoolTest.cs
@@ -575,7 +575,7 @@ namespace UnitTest
             {
                 Interlocked.Increment(ref doneCount);
 
-                if (e.ID == id0)
+                if (doneCount == 1)
                 {
                     powerPool.QueueWorkItem(() =>
                     {
@@ -584,7 +584,7 @@ namespace UnitTest
                     }, new WorkOption
                     {
                         ShouldStoreResult = true,
-                        Dependents = new ConcurrentSet<string> { id0 }
+                        Dependents = new ConcurrentSet<string> { e.ID }
                     });
                 }
             };


### PR DESCRIPTION
…nd call WorkEnded before QueueWorkItem returns its ID