### PR TITLE
docs: Document rationale for QueueWorkItem overloads

### DIFF
--- a/PowerThreadPool/Core/PowerThreadPool.QueueWorkItem.cs
+++ b/PowerThreadPool/Core/PowerThreadPool.QueueWorkItem.cs
@@ -9,6 +9,16 @@ using PowerThreadPool.Works;
 
 namespace PowerThreadPool
 {
+    /// <summary>
+    /// There are a great many overloads of QueueWorkItem, but this is the conventional .NET approach.
+    /// I want to keep the API strongly typed without introducing a source generator, 
+    /// so I’m trading space for ease of use.
+    /// Considering that:
+    /// https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Tuple.cs
+    /// https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Action.cs
+    /// https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Function.cs
+    /// all use a similar brute-force overloading pattern, I think this is unavoidable.
+    /// </summary>
     public partial class PowerPool
     {
         private long _workIDIncrement = 0;


### PR DESCRIPTION
Add an XML summary to PowerPool explaining the design choice to provide many QueueWorkItem overloads. The comment notes the intent to keep the API strongly typed without a source generator (trading binary size for ease of use) and cites similar brute-force overloading patterns in the .NET runtime (Tuple/Action/Function) as precedent. This is a documentation-only change in PowerThreadPool/Core/PowerThreadPool.QueueWorkItem.cs.