### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/ZjzMisaka/PowerThreadPool/security/code-scanning/3](https://github.com/ZjzMisaka/PowerThreadPool/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (currently just `benchmark`) without changing behavior. For this workflow, the minimal required starting point is:

- `contents: read`

This supports `actions/checkout` and keeps the token constrained. No new imports, methods, or dependencies are needed (YAML workflow change only).

Change location:
- File: `.github/workflows/benchmarks.yml`
- Insert `permissions:` after the trigger section (`on:` block) and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
